### PR TITLE
Add uart_system_init helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A professional, modular UART driver package for STM32 microcontrollers. Designed
 - Configure queue sizes, stack sizes, priorities.
 
 ### FreeRTOS Integration
-- Initialization API: `UART_Driver_Init()`
+- Initialization helper: `uart_system_init()`
 - Optional task creation for Command and Logging modules.
 - Weak task definitions allow user override.
 - Clean shutdown API provided.

--- a/examples/freertos_example/main_w_Command.c
+++ b/examples/freertos_example/main_w_Command.c
@@ -55,16 +55,10 @@ int main(void)
   MX_USART2_UART_Init();
 
 
-  // Initialize the UART driver
-  if (uart_init(&uart2_drv, &huart2, &hdma_usart2_tx, &hdma_usart2_rx) != UART_OK) {
+  // Initialize the UART driver and enabled modules
+  if (uart_system_init(&uart2_drv, &huart2, &hdma_usart2_tx, &hdma_usart2_rx) != UART_OK) {
       Error_Handler();
   }
-
-  // Initialize the command interpreter
-  // This creates the RTOS queue & task
-  cmd_init(&uart2_drv);
-
-  log_init(&uart2_drv);
 
   /* Create the thread(s) */
   /* definition and creation of defaultTask */

--- a/examples/freertos_example/main_wo_Command.c
+++ b/examples/freertos_example/main_wo_Command.c
@@ -45,8 +45,7 @@ int main(void)
   MX_ADC1_Init();
   MX_TIM2_Init();
 
-  uart_init(&shared_uart, &huart2, &hdma_usart2_tx, &hdma_usart2_rx);
-  log_init(&shared_uart);
+  uart_system_init(&shared_uart, &huart2, &hdma_usart2_tx, &hdma_usart2_rx);
   log_write(LOG_LEVEL_INFO, "Started");
 
   osThreadDef(defaultTask, StartDefaultTask, osPriorityNormal, 0, 128);

--- a/include/uart_driver.h
+++ b/include/uart_driver.h
@@ -55,6 +55,18 @@ uart_status_t uart_init(uart_drv_t *drv,
                         DMA_HandleTypeDef  *hdma_rx);
 
 /**
+ * @brief Convenience initializer that also sets up optional modules.
+ *
+ * This will invoke @ref uart_init and then call @ref cmd_init and
+ * @ref log_init automatically when the corresponding feature macros
+ * are enabled in `uart_driver_config.h`.
+ */
+uart_status_t uart_system_init(uart_drv_t *drv,
+                               UART_HandleTypeDef *huart,
+                               DMA_HandleTypeDef  *hdma_tx,
+                               DMA_HandleTypeDef  *hdma_rx);
+
+/**
  * @brief Deinitialize a driver instance (frees its mutexes).
  */
 void uart_deinit(uart_drv_t *drv);

--- a/src/uart_driver.c
+++ b/src/uart_driver.c
@@ -8,6 +8,12 @@
 
 #include "uart_driver.h"
 #include "uart_driver_config.h"
+#if USE_CMD_INTERPRETER
+#include "command_module.h"
+#endif
+#if LOGGING_ENABLED
+#include "logging.h"
+#endif
 
 #define UART_DRV_MAX_INSTANCES 4
 
@@ -190,6 +196,24 @@ void uart_flush_tx(uart_drv_t *drv) {
 
 uart_status_t uart_get_status(uart_drv_t *drv) {
     return drv->status;
+}
+
+uart_status_t uart_system_init(uart_drv_t *drv,
+                               UART_HandleTypeDef *huart,
+                               DMA_HandleTypeDef  *hdma_tx,
+                               DMA_HandleTypeDef  *hdma_rx)
+{
+    uart_status_t ret = uart_init(drv, huart, hdma_tx, hdma_rx);
+    if (ret != UART_OK)
+        return ret;
+
+#if USE_CMD_INTERPRETER
+    cmd_init(drv);
+#endif
+#if LOGGING_ENABLED
+    log_init(drv);
+#endif
+    return UART_OK;
 }
 
 // Callback registration

--- a/usage.md
+++ b/usage.md
@@ -34,7 +34,7 @@ These defaults are visible in [`uart_driver_config.h`](include/uart_driver_confi
 2. Create a `uart_drv_t` instance and call:
    ```c
    uart_drv_t uart;
-   uart_init(&uart, &huart, &hdma_tx, &hdma_rx); // DMA handles may be NULL
+   uart_system_init(&uart, &huart, &hdma_tx, &hdma_rx); // DMA handles may be NULL
    ```
 3. Use the blocking or non-blocking APIs to transmit and receive:
    ```c
@@ -44,21 +44,15 @@ These defaults are visible in [`uart_driver_config.h`](include/uart_driver_confi
 
 ## Command Interpreter
 
-When `USE_CMD_INTERPRETER` is enabled call `cmd_init()` after initializing the UART driver:
-
-```c
-cmd_init(&uart);
-```
+`uart_system_init()` automatically starts the interpreter when `USE_CMD_INTERPRETER` is set. You can also call `cmd_init()` manually if finer control is required.
 
 Commands are defined by filling a `Command` table (see [`sample_commands.c`](src/sample_commands.c)) and implementing handlers that accept an `Args *` structure.
 
 ## Logging and Telemetry
 
-If `LOGGING_ENABLED` is set, initialize the logger with:
-```c
-log_init(&uart);
-```
-Then log messages from any task:
+When `LOGGING_ENABLED` is non-zero, `uart_system_init()` invokes
+`log_init()` automatically. You can still call `log_init()` yourself
+if the driver was brought up manually. Then log messages from any task:
 ```c
 log_write(LOG_LEVEL_INFO, "Started");
 ```


### PR DESCRIPTION
## Summary
- add new `uart_system_init()` API that initializes the driver plus optional modules
- mention the helper in the README and usage docs
- update examples to use the unified initializer

## Testing
- `gcc -c src/uart_driver.c src/command_module.c src/logging.c src/fault_module.c src/sample_commands.c -Iinclude -DUSE_CMD_INTERPRETER=1 -DLOGGING_ENABLED=1` *(fails: `FreeRTOS.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886bc4511ec8323aefec2e1645d988d