### PR TITLE
Rename sample commands module to commands

### DIFF
--- a/examples/freertos_example/main_w_Command.c
+++ b/examples/freertos_example/main_w_Command.c
@@ -2,7 +2,7 @@
 #include "cmsis_os.h"
 #include "uart_driver.h"
 #include <string.h>
-#include "sample_commands.h"
+#include "commands.h"
 #include "command_module.h"
 #include "logging.h"
 

--- a/include/command_module.h
+++ b/include/command_module.h
@@ -26,9 +26,7 @@ typedef struct {
     void      (*handler)(Args *args);
 } Command;
 
-/** Application-defined command table */
-extern const Command cmd_list[];
-extern const size_t  cmd_count;
+
 
 /**
  * @brief Initialize command interpreter.

--- a/include/commands.h
+++ b/include/commands.h
@@ -1,8 +1,8 @@
-#ifndef SAMPLE_COMMANDS_H
-#define SAMPLE_COMMANDS_H
+#ifndef COMMANDS_H
+#define COMMANDS_H
 /**
- * @file sample_commands.h
- * @brief Example set of CLI command handlers.
+ * @file commands.h
+ * @brief CLI command handlers for demo application.
  */
 
 #include "command_module.h"
@@ -24,4 +24,4 @@ extern const Command cmd_list[];
 /** Number of commands in ::cmd_list. */
 extern const size_t  cmd_count;
 
-#endif // SAMPLE_COMMANDS_H
+#endif // COMMANDS_H

--- a/src/command_module.c
+++ b/src/command_module.c
@@ -5,6 +5,7 @@
  *      Author: kevinfox
  */
 #include "command_module.h"
+#include "commands.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,10 +1,10 @@
 /*
- * sample_commands.c
+ * commands.c
  *
  *  Created on: Jul 20, 2025
  *      Author: kevinfox
  */
-#include "sample_commands.h"
+#include "commands.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/usage.md
+++ b/usage.md
@@ -50,7 +50,7 @@ When `USE_CMD_INTERPRETER` is enabled call `cmd_init()` after initializing the U
 cmd_init(&uart);
 ```
 
-Commands are defined by filling a `Command` table (see [`sample_commands.c`](src/sample_commands.c)) and implementing handlers that accept an `Args *` structure.
+Commands are defined by filling a `Command` table (see [`commands.c`](src/commands.c)) and implementing handlers that accept an `Args *` structure.
 
 ## Logging and Telemetry
 


### PR DESCRIPTION
## Summary
- rename sample command files and update includes
- revise header guard and comments
- clean up command_module.h externs
- update docs and example references

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6886bcee7264832380df9975d4daad3b