### PR TITLE
Refactor logging for modularity

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -65,6 +65,11 @@ void log_write(LogLevel level, const char *fmt, ...);
 /** Send a telemetry packet. */
 void telemetry_send(const TelemetryPacket *pkt);
 
+/**
+ * @brief Set the minimum severity level for log output.
+ */
+void log_set_level(LogLevel level);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- allow runtime control over log severity
- refactor logger task into queue, telemetry, and fault helpers

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688fff45fbc883238a93fdaa99792f42