### PR TITLE
Normalize global feature macros

### DIFF
--- a/include/uart_driver.h
+++ b/include/uart_driver.h
@@ -18,10 +18,10 @@
 #include "uart_driver_config.h"
 #include "uart_driver_abstraction.h"
 
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
   #include "FreeRTOS.h"
   #include "semphr.h"
-  #ifdef USE_CMSIS_RTOS
+  #if USE_CMSIS_RTOS
     #include "cmsis_os.h"
   #endif
 #endif
@@ -172,10 +172,10 @@ struct uart_drv_handle_s {
 #endif
 
     /* FreeRTOS synchronization (when enabled) */
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     SemaphoreHandle_t   tx_mutex;
     SemaphoreHandle_t   rx_mutex;
-#endif
+#endif /* USE_FREERTOS */
     
     /* Status and callback management */
     uart_callback_t     cb;

--- a/include/uart_driver_abstraction.h
+++ b/include/uart_driver_abstraction.h
@@ -80,12 +80,12 @@ typedef struct {
     uint16_t tx_count;
     uint16_t rx_count;
     
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     SemaphoreHandle_t tx_mutex;
     SemaphoreHandle_t rx_mutex;
     SemaphoreHandle_t tx_complete_sem;
     SemaphoreHandle_t rx_complete_sem;
-#endif
+#endif /* USE_FREERTOS */
 } uart_abstraction_handle_t;
 
 /*******************************************************************************
@@ -174,7 +174,7 @@ uint32_t uart_abstraction_is_rx_complete(uart_abstraction_handle_t *handle);
 /*******************************************************************************
  * CMSIS-RTOS2 Integration Functions
  ******************************************************************************/
-#if defined(USE_FREERTOS) && defined(USE_CMSIS_RTOS)
+#if USE_FREERTOS && USE_CMSIS_RTOS
 
 /**
  * @brief CMSIS-RTOS2 compatible transmit with timeout

--- a/include/uart_driver_config.h
+++ b/include/uart_driver_config.h
@@ -42,11 +42,11 @@
  * Tick source & critical‐section abstraction
  ******************************************************************************/
 
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
   #include "FreeRTOS.h"
   #include "task.h"
   #include "semphr.h"
-  #ifdef USE_CMSIS_RTOS
+  #if USE_CMSIS_RTOS
     #include "cmsis_os.h"
   #endif
   #define TICKS_PER_SECOND       configTICK_RATE_HZ
@@ -67,7 +67,7 @@
   #define GET_TICKS()            HAL_GetTick()
   #define FAULT_ENTER_CRITICAL() __disable_irq()
   #define FAULT_EXIT_CRITICAL()  __enable_irq()
-#endif
+#endif /* USE_FREERTOS */
 
 
 #endif /* UART_DRIVER_CONFIG_H */

--- a/src/uart_driver_abstraction.c
+++ b/src/uart_driver_abstraction.c
@@ -132,7 +132,7 @@ uart_abstraction_status_t uart_abstraction_init(uart_abstraction_handle_t *handl
     handle->tx_count = 0;
     handle->rx_count = 0;
     
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     /* Create FreeRTOS synchronization objects */
     handle->tx_mutex = xSemaphoreCreateMutex();
     handle->rx_mutex = xSemaphoreCreateMutex();
@@ -143,7 +143,7 @@ uart_abstraction_status_t uart_abstraction_init(uart_abstraction_handle_t *handl
         !handle->tx_complete_sem || !handle->rx_complete_sem) {
         return UART_ABSTRACTION_ERROR;
     }
-#endif
+#endif /* USE_FREERTOS */
     
 #if USE_STM32_LL_DRIVERS
     return uart_ll_init(handle);
@@ -158,7 +158,7 @@ void uart_abstraction_deinit(uart_abstraction_handle_t *handle)
         return;
     }
     
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     /* Clean up FreeRTOS objects */
     if (handle->tx_mutex) {
         vSemaphoreDelete(handle->tx_mutex);
@@ -172,7 +172,7 @@ void uart_abstraction_deinit(uart_abstraction_handle_t *handle)
     if (handle->rx_complete_sem) {
         vSemaphoreDelete(handle->rx_complete_sem);
     }
-#endif
+#endif /* USE_FREERTOS */
     
     /* Reset state */
     memset(handle, 0, sizeof(uart_abstraction_handle_t));
@@ -187,7 +187,7 @@ uart_abstraction_status_t uart_abstraction_transmit(uart_abstraction_handle_t *h
         return UART_ABSTRACTION_ERROR;
     }
     
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     /* Take mutex with timeout */
     if (xSemaphoreTake(handle->tx_mutex, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
         return UART_ABSTRACTION_TIMEOUT;
@@ -231,9 +231,9 @@ uart_abstraction_status_t uart_abstraction_transmit(uart_abstraction_handle_t *h
 #endif
     
 cleanup:
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     xSemaphoreGive(handle->tx_mutex);
-#endif
+#endif /* USE_FREERTOS */
     
     return result;
 }
@@ -247,7 +247,7 @@ uart_abstraction_status_t uart_abstraction_receive(uart_abstraction_handle_t *ha
         return UART_ABSTRACTION_ERROR;
     }
     
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     /* Take mutex with timeout */
     if (xSemaphoreTake(handle->rx_mutex, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
         return UART_ABSTRACTION_TIMEOUT;
@@ -282,9 +282,9 @@ uart_abstraction_status_t uart_abstraction_receive(uart_abstraction_handle_t *ha
 #endif
     
 cleanup:
-#ifdef USE_FREERTOS
+#if USE_FREERTOS
     xSemaphoreGive(handle->rx_mutex);
-#endif
+#endif /* USE_FREERTOS */
     
     return result;
 }
@@ -438,7 +438,7 @@ uint32_t uart_abstraction_is_rx_complete(uart_abstraction_handle_t *handle)
 /*******************************************************************************
  * CMSIS-RTOS2 Integration
  ******************************************************************************/
-#if defined(USE_FREERTOS) && defined(USE_CMSIS_RTOS)
+#if USE_FREERTOS && USE_CMSIS_RTOS
 
 uart_abstraction_status_t uart_abstraction_transmit_rtos(uart_abstraction_handle_t *handle,
                                                          uint8_t *data,


### PR DESCRIPTION
## Summary
- make FreeRTOS/CMSIS macros numeric and global
- apply consistent `#if` checks across driver and abstraction layers

## Testing
- `gcc -c src/uart_driver_abstraction.c -Iinclude -Iexamples/freertos_example/Drivers/STM32F4xx_HAL_Driver/Inc -Iexamples/freertos_example/Core/Inc -Iexamples/freertos_example/Drivers/CMSIS/Device/ST/STM32F4xx/Include -Iexamples/freertos_example/Drivers/CMSIS/Include -DUSE_FREERTOS=0 -DUSE_CMSIS_RTOS=0 -DUSE_STM32_LL_DRIVERS=0 -DSTM32F446xx -std=c99` *(fails: FreeRTOS.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689748e20894832396e0d5dab6342c7f