### PR TITLE
chore: remove outdated headers and dead code

### DIFF
--- a/src/command_module.c
+++ b/src/command_module.c
@@ -1,8 +1,6 @@
-/*
- * command_module.c
- *
- *  Created on: Jul 20, 2025
- *      Author: kevinfox
+/**
+ * @file command_module.c
+ * @brief Simple command interpreter over UART.
  */
 #include "command_module.h"
 #include "commands.h"

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,8 +1,6 @@
-/*
- * commands.c
- *
- *  Created on: Jul 20, 2025
- *      Author: kevinfox
+/**
+ * @file commands.c
+ * @brief Example command handlers for UART driver.
  */
 #include "commands.h"
 #include <stdio.h>

--- a/src/logging.c
+++ b/src/logging.c
@@ -1,8 +1,6 @@
-/*
- * logging.c
- *
- *  Created on: Jul 20, 2025
- *      Author: kevinfox
+/**
+ * @file logging.c
+ * @brief Logging and telemetry utilities.
  */
 #include "logging.h"
 #include "fault_module.h"

--- a/src/uart_driver.c
+++ b/src/uart_driver.c
@@ -1,10 +1,7 @@
-/*
- * uart_driver.c
- *
- *  Created on: Jul 19, 2025
- *      Author: kevinfox
+/**
+ * @file uart_driver.c
+ * @brief Thread-safe UART driver implementation.
  */
-// uart_driver.c
 
 #include "uart_driver.h"
 #include "uart_driver_config.h"
@@ -190,8 +187,7 @@ void uart_flush_rx(uart_drv_t *drv) {
 }
 
 void uart_flush_tx(uart_drv_t *drv) {
-//    __HAL_UART_CLEAR_TCFLAG(drv->huart);
-	__HAL_UART_CLEAR_FLAG(drv->huart, UART_FLAG_TC);
+    __HAL_UART_CLEAR_FLAG(drv->huart, UART_FLAG_TC);
 }
 
 uart_status_t uart_get_status(uart_drv_t *drv) {

--- a/usage.md
+++ b/usage.md
@@ -56,7 +56,19 @@ log_write(LOG_LEVEL_INFO, "Started");
 ```
 Telemetry packets can be queued via `telemetry_send(&pkt);` when `TELEMETRY_ENABLED` is non-zero.
 
+## Enabling Floating-Point printf in CMake
+
+Many embedded toolchains omit floating-point support from `printf` to save
+flash. When using CMake with newlib-nano, enable `%f` formatting by linking
+with `_printf_float`:
+
+```cmake
+target_link_options(your_target PRIVATE -Wl,-u,_printf_float)
+```
+
+Add `_scanf_float` in the same manner if floating-point scanning is required.
+
 ## Examples
 
-Complete integration examples using FreeRTOS are provided under [`examples/freertos_example`](examples/freertos_example). 
+Complete integration examples using FreeRTOS are provided under [`examples/freertos_example`](examples/freertos_example).
 `main_wo_Command.c` demonstrates a minimal setup without the command interpreter, while `main_w_Command.c` showcases a feature-rich setup with the command interpreter enabled.


### PR DESCRIPTION
## Summary
- streamline source headers and drop stale creation metadata
- remove unused UART flag-clearing stub
- document how to enable float `printf` when using CMake

## Testing
- `gcc -Iinclude -c src/uart_driver.c` *(fails: FreeRTOS.h: No such file or directory)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68974c00412483239f9558454ad2e5f3