### PR TITLE
Auto-init command interpreter for LL UART system init

### DIFF
--- a/examples/freertos_ll_example.c
+++ b/examples/freertos_ll_example.c
@@ -56,25 +56,19 @@ int main(void)
     MX_DMA_Init_LL();
     MX_USART2_UART_Init_LL();
     
-    /* Initialize UART driver with LL backend */
-    uart_status_t uart_result = uart_init_ll(&main_uart, 
-                                             USART2,        // LL UART instance
-                                             DMA1,          // TX DMA instance
-                                             DMA1,          // RX DMA instance  
-                                             LL_DMA_STREAM_6, // TX stream
-                                             LL_DMA_STREAM_5); // RX stream
-    
+    /* Initialize UART driver with LL backend and optional modules */
+    uart_status_t uart_result = uart_system_init_ll(&main_uart,
+                                                   USART2,        // LL UART instance
+                                                   DMA1,          // TX DMA instance
+                                                   DMA1,          // RX DMA instance
+                                                   LL_DMA_STREAM_6, // TX stream
+                                                   LL_DMA_STREAM_5); // RX stream
+
     if (uart_result != UART_OK) {
         Error_Handler();
     }
-    
-    /* Initialize optional modules */
-#if USE_CMD_INTERPRETER
-    cmd_init(&main_uart);
-#endif
 
 #if LOGGING_ENABLED
-    log_init(&main_uart);
     LOG_INFO("STM32 UART Driver Plus - LL Example Started");
     LOG_INFO("Configuration: LL drivers + FreeRTOS");
 #endif
@@ -125,11 +119,8 @@ static void UART_Communication_Task(void *pvParameters)
             
             /* Process command if newline received */
             if (rx_buffer[0] == '\r' || rx_buffer[0] == '\n') {
-#if USE_CMD_INTERPRETER
-                /* Command interpreter will handle the command */
-                cmd_process_line();
-#endif
-                
+                /* Command interpreter will automatically handle the command */
+
                 /* Send periodic status message */
                 char status_msg[64];
                 snprintf(status_msg, sizeof(status_msg), 

--- a/src/uart_driver.c
+++ b/src/uart_driver.c
@@ -194,6 +194,28 @@ uart_status_t uart_get_status(uart_drv_t *drv) {
     return drv->status;
 }
 
+#if USE_STM32_LL_DRIVERS
+uart_status_t uart_system_init_ll(uart_drv_t *drv,
+                                  USART_TypeDef *uart_instance,
+                                  DMA_TypeDef   *dma_tx_instance,
+                                  DMA_TypeDef   *dma_rx_instance,
+                                  uint32_t      dma_tx_stream,
+                                  uint32_t      dma_rx_stream)
+{
+    uart_status_t ret = uart_init_ll(drv, uart_instance, dma_tx_instance,
+                                     dma_rx_instance, dma_tx_stream, dma_rx_stream);
+    if (ret != UART_OK)
+        return ret;
+
+#if USE_CMD_INTERPRETER
+    cmd_init(drv);
+#endif
+#if LOGGING_ENABLED
+    log_init(drv);
+#endif
+    return UART_OK;
+}
+#else
 uart_status_t uart_system_init(uart_drv_t *drv,
                                UART_HandleTypeDef *huart,
                                DMA_HandleTypeDef  *hdma_tx,
@@ -211,6 +233,7 @@ uart_status_t uart_system_init(uart_drv_t *drv,
 #endif
     return UART_OK;
 }
+#endif
 
 // Callback registration
 


### PR DESCRIPTION
## Summary
- add uart_system_init_ll convenience function that initializes command interpreter and logging modules
- update LL FreeRTOS example to use uart_system_init_ll and remove manual command init

## Testing
- `gcc -Iinclude -c src/uart_driver.c -o /tmp/uart_driver.o` (fails: FreeRTOS.h not found)
- `gcc -Iinclude -c examples/freertos_ll_example.c -o /tmp/freertos_ll_example.o` (fails: main.h not found)


------
https://chatgpt.com/codex/tasks/task_e_68975ba4c1348323983064b32c020171