### PR TITLE
Guard command modules when interpreter is disabled

### DIFF
--- a/examples/freertos_example/Drivers/LoggerPlus/include/command_module.h
+++ b/examples/freertos_example/Drivers/LoggerPlus/include/command_module.h
@@ -5,14 +5,14 @@
  * @brief Lightweight UART command interpreter.
  */
 
+#include "uart_driver.h"
+#include "uart_driver_config.h"
+
+#if USE_CMD_INTERPRETER
 #include "FreeRTOS.h"
 #include "queue.h"
 #include "task.h"
-#include "uart_driver.h"
-#include "uart_driver_config.h"
-#include <stdbool.h>
-
-#if USE_CMD_INTERPRETER
+#endif
 
 /** Parsed argument list provided to command handlers. */
 typedef struct {
@@ -26,7 +26,7 @@ typedef struct {
     void      (*handler)(Args *args);
 } Command;
 
-
+#if USE_CMD_INTERPRETER
 
 /**
  * @brief Initialize command interpreter.
@@ -41,6 +41,13 @@ void cmd_write(const char *s);
 void cmd_printf(const char *fmt, ...);
 /** Get the UART driver used by the command interpreter. */
 uart_drv_t* cmd_get_uart_driver(void);
+
+#else
+
+static inline void cmd_init(uart_drv_t *uart) {(void)uart;}
+static inline void cmd_write(const char *s) {(void)s;}
+static inline void cmd_printf(const char *fmt, ...) {(void)fmt;}
+static inline uart_drv_t* cmd_get_uart_driver(void) {return NULL;}
 
 #endif // USE_CMD_INTERPRETER
 #endif // COMMAND_MODULE_H

--- a/examples/freertos_example/Drivers/LoggerPlus/include/commands.h
+++ b/examples/freertos_example/Drivers/LoggerPlus/include/commands.h
@@ -5,8 +5,10 @@
  * @brief CLI command handlers for demo application.
  */
 
-#include "command_module.h"
+#include "uart_driver_config.h"
 
+#if USE_CMD_INTERPRETER
+#include "command_module.h"
 
 /** Print list of supported commands. */
 void cmd_help(Args *args);
@@ -29,5 +31,6 @@ void cmd_protocol(Args *args);
 extern const Command cmd_list[];
 /** Number of commands in ::cmd_list. */
 extern const size_t  cmd_count;
+#endif
 
 #endif // COMMANDS_H

--- a/examples/freertos_example/Drivers/LoggerPlus/src/commands.c
+++ b/examples/freertos_example/Drivers/LoggerPlus/src/commands.c
@@ -4,6 +4,8 @@
  *  Created on: Jul 20, 2025
  *      Author: kevinfox
  */
+#include "uart_driver_config.h"
+#if USE_CMD_INTERPRETER
 #include "commands.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -398,3 +400,4 @@ const Command cmd_list[] = {
 };
 const size_t cmd_count = sizeof(cmd_list) / sizeof(cmd_list[0]);
 
+#endif // USE_CMD_INTERPRETER

--- a/include/command_module.h
+++ b/include/command_module.h
@@ -5,14 +5,14 @@
  * @brief Lightweight UART command interpreter.
  */
 
+#include "uart_driver.h"
+#include "uart_driver_config.h"
+
+#if USE_CMD_INTERPRETER
 #include "FreeRTOS.h"
 #include "queue.h"
 #include "task.h"
-#include "uart_driver.h"
-#include "uart_driver_config.h"
-#include <stdbool.h>
-
-#if USE_CMD_INTERPRETER
+#endif
 
 /** Parsed argument list provided to command handlers. */
 typedef struct {
@@ -26,7 +26,7 @@ typedef struct {
     void      (*handler)(Args *args);
 } Command;
 
-
+#if USE_CMD_INTERPRETER
 
 /**
  * @brief Initialize command interpreter.
@@ -39,6 +39,12 @@ void cmd_init(uart_drv_t *uart);
 void cmd_write(const char *s);
 /** printf style helper using the interpreter's UART. */
 void cmd_printf(const char *fmt, ...);
+
+#else
+
+static inline void cmd_init(uart_drv_t *uart) {(void)uart;}
+static inline void cmd_write(const char *s) {(void)s;}
+static inline void cmd_printf(const char *fmt, ...) {(void)fmt;}
 
 #endif // USE_CMD_INTERPRETER
 #endif // COMMAND_MODULE_H

--- a/include/commands.h
+++ b/include/commands.h
@@ -5,8 +5,10 @@
  * @brief CLI command handlers for demo application.
  */
 
-#include "command_module.h"
+#include "uart_driver_config.h"
 
+#if USE_CMD_INTERPRETER
+#include "command_module.h"
 
 /** Print list of supported commands. */
 void cmd_help(Args *args);
@@ -23,5 +25,6 @@ void cmd_fault_clear(Args *args);
 extern const Command cmd_list[];
 /** Number of commands in ::cmd_list. */
 extern const size_t  cmd_count;
+#endif
 
 #endif // COMMANDS_H

--- a/src/commands.c
+++ b/src/commands.c
@@ -2,6 +2,10 @@
  * @file commands.c
  * @brief Example command handlers for UART driver.
  */
+
+#include "uart_driver_config.h"
+#if USE_CMD_INTERPRETER
+
 #include "commands.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -94,4 +98,6 @@ const Command cmd_list[] = {
     { "fault_clear", cmd_fault_clear },
 };
 const size_t cmd_count = sizeof(cmd_list) / sizeof(cmd_list[0]);
+
+#endif // USE_CMD_INTERPRETER
 


### PR DESCRIPTION
## Summary
- Provide no-op cmd_init/cmd_write/cmd_printf when `USE_CMD_INTERPRETER` is 0
- Wrap command headers and sources in `USE_CMD_INTERPRETER` checks
- Mirror the same safeguards in example command modules

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68976237beb08323bbbfec5df692e141