### PR TITLE
Add UART command to set logging level

### DIFF
--- a/examples/freertos_example/Drivers/LoggerPlus/include/commands.h
+++ b/examples/freertos_example/Drivers/LoggerPlus/include/commands.h
@@ -20,6 +20,8 @@ void cmd_add(Args *args);
 void cmd_faults(Args *args);
 /** Clear specific or all faults. */
 void cmd_fault_clear(Args *args);
+/** Set minimum logging level. */
+void cmd_log_level(Args *args);
 /** Control PWM output duty cycle and state. */
 void cmd_pwm(Args *args);
 /** Read ADC values and control ADC conversion. */

--- a/examples/freertos_example/Drivers/LoggerPlus/include/logging.h
+++ b/examples/freertos_example/Drivers/LoggerPlus/include/logging.h
@@ -65,6 +65,9 @@ void log_write(LogLevel level, const char *fmt, ...);
 /** Send a telemetry packet. */
 void telemetry_send(const TelemetryPacket *pkt);
 
+/** Set the minimum severity level for log output. */
+void log_set_level(LogLevel level);
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/freertos_example/Drivers/LoggerPlus/src/commands.c
+++ b/examples/freertos_example/Drivers/LoggerPlus/src/commands.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fault_module.h"
+#include "logging.h"
 #include "main.h"
 #include "FreeRTOS.h"
 #include "task.h"
@@ -99,6 +100,27 @@ void cmd_fault_clear(Args *args) {
             send_str("Fault cleared\r\n");
         }
     }
+}
+
+// 'log_level' command: adjust logging verbosity
+void cmd_log_level(Args *args) {
+    if (args->argc != 2) {
+        send_str("Usage: log_level <debug|info|warn|error|fatal>\r\n");
+        return;
+    }
+    LogLevel level;
+    const char *arg = args->argv[1];
+    if (strcmp(arg, "debug") == 0) level = LOG_LEVEL_DEBUG;
+    else if (strcmp(arg, "info") == 0) level = LOG_LEVEL_INFO;
+    else if (strcmp(arg, "warn") == 0) level = LOG_LEVEL_WARN;
+    else if (strcmp(arg, "error") == 0) level = LOG_LEVEL_ERROR;
+    else if (strcmp(arg, "fatal") == 0) level = LOG_LEVEL_FATAL;
+    else {
+        send_str("Invalid level\r\n");
+        return;
+    }
+    log_set_level(level);
+    send_str("Log level updated\r\n");
 }
 
 // 'pwm' command: control PWM duty cycle
@@ -394,6 +416,7 @@ const Command cmd_list[] = {
     { "add",  cmd_add   },
     { "faults", cmd_faults },
     { "fault_clear", cmd_fault_clear },
+    { "log_level", cmd_log_level },
     { "pwm", cmd_pwm },
     { "adc", cmd_adc },
     { "protocol", cmd_protocol },

--- a/examples/freertos_example/Drivers/LoggerPlus/src/logging.c
+++ b/examples/freertos_example/Drivers/LoggerPlus/src/logging.c
@@ -95,6 +95,13 @@ void telemetry_send(const TelemetryPacket *pkt)
 #endif
 }
 
+void log_set_level(LogLevel level)
+{
+#if LOGGING_ENABLED
+    current_level = level;
+#endif
+}
+
 
 // Logging task: drain queue and transmit
 static void log_task(void *arg)

--- a/include/commands.h
+++ b/include/commands.h
@@ -20,6 +20,8 @@ void cmd_add(Args *args);
 void cmd_faults(Args *args);
 /** Clear specific or all faults. */
 void cmd_fault_clear(Args *args);
+/** Set minimum logging level. */
+void cmd_log_level(Args *args);
 
 /** Table of available commands. */
 extern const Command cmd_list[];

--- a/src/commands.c
+++ b/src/commands.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fault_module.h"
+#include "logging.h"
 
 // Helper to send strings using command module UART
 static void send_str(const char *s) {
@@ -89,6 +90,27 @@ void cmd_fault_clear(Args *args) {
     }
 }
 
+// 'log_level' command: adjust logging verbosity
+void cmd_log_level(Args *args) {
+    if (args->argc != 2) {
+        send_str("Usage: log_level <debug|info|warn|error|fatal>\r\n");
+        return;
+    }
+    LogLevel level;
+    const char *arg = args->argv[1];
+    if (strcmp(arg, "debug") == 0) level = LOG_LEVEL_DEBUG;
+    else if (strcmp(arg, "info") == 0) level = LOG_LEVEL_INFO;
+    else if (strcmp(arg, "warn") == 0) level = LOG_LEVEL_WARN;
+    else if (strcmp(arg, "error") == 0) level = LOG_LEVEL_ERROR;
+    else if (strcmp(arg, "fatal") == 0) level = LOG_LEVEL_FATAL;
+    else {
+        send_str("Invalid level\r\n");
+        return;
+    }
+    log_set_level(level);
+    send_str("Log level updated\r\n");
+}
+
 // Define command table and expose to interpreter
 const Command cmd_list[] = {
     { "help", cmd_help },
@@ -96,6 +118,7 @@ const Command cmd_list[] = {
     { "add",  cmd_add   },
     { "faults", cmd_faults },
     { "fault_clear", cmd_fault_clear },
+    { "log_level", cmd_log_level },
 };
 const size_t cmd_count = sizeof(cmd_list) / sizeof(cmd_list[0]);
 


### PR DESCRIPTION
## Summary
- Allow runtime adjustment of log verbosity using new `log_level` UART command
- Expose `log_set_level` API in example logging module
- Update command tables and headers to include log level control

## Testing
- `gcc -std=c11 -Wall -Wextra -c src/commands.c -Iinclude` *(fails: FreeRTOS.h: No such file or directory)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6897f869076883239e20086ecb95db18